### PR TITLE
Refactor: Initial rebranding to FreeSea and URL updates

### DIFF
--- a/lunasea-cloud-functions/functions/src/services/storage/index.ts
+++ b/lunasea-cloud-functions/functions/src/services/storage/index.ts
@@ -1,6 +1,6 @@
 import * as admin from 'firebase-admin';
 import { deleteUser } from './delete_user';
 
-const getBackupBucket = () => admin.storage().bucket('backup.lunasea.app');
+const getBackupBucket = () => admin.storage().bucket('backup.crushcodeworks.com/freesea');
 
 export { deleteUser, getBackupBucket };

--- a/lunasea-docs/README.md
+++ b/lunasea-docs/README.md
@@ -21,7 +21,7 @@ LunaSea is purely a remote control application, it does not offer any functional
 
 ## Releases
 
-All releases for every build channel can be downloaded from the [build bucket](https://builds.lunasea.app/), and all stable releases for all platforms are also available on [GitHub](https://github.com/JagandeepBrar/LunaSea/releases).
+All releases for every build channel can be downloaded from the [build bucket](https://builds.crushcodeworks.com/freesea/), and all stable releases for all platforms are also available on [GitHub](https://github.com/JagandeepBrar/LunaSea/releases).
 
 * [Android](releases/android.md)
 * [iOS](releases/ios.md)

--- a/lunasea-docs/getting-started/build-channels.md
+++ b/lunasea-docs/getting-started/build-channels.md
@@ -2,7 +2,7 @@
 
 LunaSea offers four different build channels, each of which supply signed and notarized copies of LunaSea.
 
-All releases for every build channel can be downloaded from the [build bucket](https://builds.lunasea.app/), and all stable releases for all platforms are also available on [GitHub](https://github.com/JagandeepBrar/LunaSea/releases).
+All releases for every build channel can be downloaded from the [build bucket](https://builds.crushcodeworks.com/freesea/), and all stable releases for all platforms are also available on [GitHub](https://github.com/JagandeepBrar/LunaSea/releases).
 
 ## Stable
 

--- a/lunasea-docs/getting-started/frequently-asked-questions.md
+++ b/lunasea-docs/getting-started/frequently-asked-questions.md
@@ -21,7 +21,7 @@ Support for torrent clients is easily the most requested new module, and I defin
 Torrent support is not completely off the table and may come in the future! But at the moment, over 90% of the active user base is using iOS-based devices and it is hard to justify building a module (that takes a lot of time) that the mass majority of the user base would not be able to use.
 
 {% hint style="info" %}
-I am actively thinking of methods to get around this limitation, if you have any ideas consider commenting on the torrent client support [feedback board request](https://feedback.lunasea.app/b/New-Modules/p/torrent-clients-support).
+I am actively thinking of methods to get around this limitation, if you have any ideas consider commenting on the torrent client support [feedback board request](https://feedback.crushcodeworks.com/freesea/b/New-Modules/p/torrent-clients-support).
 {% endhint %}
 
 ## Development
@@ -48,18 +48,18 @@ The only possible reason that LunaSea will ever have any kind of payment model i
 
 I tried to make it as stable as possible, but bugs obviously will always be there. If you do run into a bug (especially a fatal/crashing bug), please also attach the logs from the application into the report - logs can be exported from the settings.
 
-* [GitHub Issues](https://www.lunasea.app/github): The best place to alert me of new issues is directly on the GitHub page. Please try to follow the template for bug reports, but again I am not overly strict and a good explanation of the issue will suffice (this may change in the future if it gets increasingly hard to manage).
-* [Discord](https://www.lunasea.app/discord)
-* [Email](https://docs.lunasea.appmailto:hello@lunasea.app/)
-* [Reddit](https://www.lunasea.app/reddit)
+* [GitHub Issues](https://www.crushcodeworks.com/freesea/github): The best place to alert me of new issues is directly on the GitHub page. Please try to follow the template for bug reports, but again I am not overly strict and a good explanation of the issue will suffice (this may change in the future if it gets increasingly hard to manage).
+* [Discord](https://www.crushcodeworks.com/freesea/discord)
+* [Email](https://docs.crushcodeworks.com/freesea/mailto:hello@crushcodeworks.com/freesea)
+* [Reddit](https://www.crushcodeworks.com/freesea/reddit)
 
 ### How Can I Request a New Feature?
 
 I consider all feedback and actively try to integrate new features that are requested by the community, big or small! You have a few ways to request new features for LunaSea:
 
-* [Discord](https://www.lunasea.app/discord)
-* [Email](https://docs.lunasea.appmailto:hello@lunasea.app/)
-* [Reddit](https://www.lunasea.app/reddit)
+* [Discord](https://www.crushcodeworks.com/freesea/discord)
+* [Email](https://docs.crushcodeworks.com/freesea/mailto:hello@crushcodeworks.com/freesea)
+* [Reddit](https://www.crushcodeworks.com/freesea/reddit)
 
 {% hint style="info" %}
 I may not have the ability to respond to all requests directly, but please be ensured I do read everything!
@@ -77,9 +77,9 @@ LunaSea took quite a runaround to initially get on the App Store because of its 
 
 The initial setup can either be incredibly easy or make you want to pull your hair out, I get that and that's what the community is here for! Please feel free to send a message to any of the listed methods to get support where either I or an awesome user in the community will surely come to help you out:
 
-* [Discord](https://www.lunasea.app/discord)
-* [Email](https://docs.lunasea.appmailto:hello@lunasea.app/)
-* [Reddit](https://www.lunasea.app/reddit)
+* [Discord](https://www.crushcodeworks.com/freesea/discord)
+* [Email](https://docs.crushcodeworks.com/freesea/mailto:hello@crushcodeworks.com/freesea)
+* [Reddit](https://www.crushcodeworks.com/freesea/reddit)
 
 A few quick tips on common problems:
 
@@ -101,6 +101,6 @@ While this is outside of the scope of this project, I can try to point you in th
 
 ### I Want to Complain! Where Can I Complain?
 
-Sorry that LunaSea is not meeting your expectations, feel free to post criticisms or complaints to any of the social platforms or directly [email me](https://docs.lunasea.appmailto:hello@lunasea.app/). I hope that I can remedy your complaints, all I ask is that you do not be abusive or disrespectful to myself or others in the community.
+Sorry that LunaSea is not meeting your expectations, feel free to post criticisms or complaints to any of the social platforms or directly [email me](https://docs.crushcodeworks.com/freesea/mailto:hello@crushcodeworks.com/freesea). I hope that I can remedy your complaints, all I ask is that you do not be abusive or disrespectful to myself or others in the community.
 
 I also kindly request that before you submit a 1-star App Store/Play Store review that you consider contacting me directly with your complaints. 1-star reviews can really hurt a smaller application's rating since we do not typically get lots of reviews.

--- a/lunasea-docs/lunasea/notifications/custom-notifications.md
+++ b/lunasea-docs/lunasea/notifications/custom-notifications.md
@@ -17,7 +17,7 @@ Alternatively, you can copy the content of the URL after the last slash (after `
 
 Custom notifications are supported by both device-based and user-based notifications, with full endpoint details below:
 
-{% swagger baseUrl="https://notify.lunasea.app" path="/v1/custom/device/:device_id" method="post" summary="Device-Based" %}
+{% swagger baseUrl="https://notify.crushcodeworks.com/freesea" path="/v1/custom/device/:device_id" method="post" summary="Device-Based" %}
 {% swagger-description %}
 Send a custom notification using a device token to a single device running LunaSea.
 {% endswagger-description %}
@@ -59,7 +59,7 @@ URL to an image that will be attached to the notification.
 {% endswagger-response %}
 {% endswagger %}
 
-{% swagger baseUrl="https://notify.lunasea.app" path="/v1/custom/user/:user_id" method="post" summary="User-Based" %}
+{% swagger baseUrl="https://notify.crushcodeworks.com/freesea" path="/v1/custom/user/:user_id" method="post" summary="User-Based" %}
 {% swagger-description %}
 Send a custom notification using a user token to all devices signed into that LunaSea account.
 {% endswagger-description %}

--- a/lunasea-docs/releases/android.md
+++ b/lunasea-docs/releases/android.md
@@ -12,22 +12,22 @@ If you want a stable experience, stick with stable releases. Want to test new bu
 
 _Channel(s): `Stable`, `Beta`, `Edge`_
 
-The easiest way for most users with Android devices would be to download releases of LunaSea directly from the [Google Play Store](https://www.lunasea.app/playstore)!
+The easiest way for most users with Android devices would be to download releases of LunaSea directly from the [Google Play Store](https://www.crushcodeworks.com/freesea/playstore)!
 
 {% tabs %}
 {% tab title="Stable" %}
-Head to the [Google Play Store](https://www.lunasea.app/playstore)!
+Head to the [Google Play Store](https://www.crushcodeworks.com/freesea/playstore)!
 {% endtab %}
 
 {% tab title="Beta" %}
-1. Head to the [Google Play Store](https://www.lunasea.app/playstore)
+1. Head to the [Google Play Store](https://www.crushcodeworks.com/freesea/playstore)
 2. Register for the test directly on the store listing
 3. Download LunaSea via the Google Play Store
 {% endtab %}
 
 {% tab title="Edge" %}
 1. Join the [LunaSea: Edge Testing](https://groups.google.com/g/lunasea-edge-test) Google Group
-2. Head to the [Google Play Store](https://www.lunasea.app/playstore)
+2. Head to the [Google Play Store](https://www.crushcodeworks.com/freesea/playstore)
 3. Register for the test directly on the store listing
 4. Download LunaSea via the Google Play Store
 {% endtab %}
@@ -38,7 +38,7 @@ Head to the [Google Play Store](https://www.lunasea.app/playstore)!
 _Channel(s): `Stable`, `Beta`, `Edge`_\
 _Format(s): `.apk`_
 
-All Android releases are available in the [Build Bucket](https://builds.lunasea.app/#latest/)!
+All Android releases are available in the [Build Bucket](https://builds.crushcodeworks.com/freesea/#latest/)!
 
 ## GitHub Releases
 

--- a/lunasea-docs/releases/ios.md
+++ b/lunasea-docs/releases/ios.md
@@ -12,7 +12,7 @@ If you want a stable experience, stick with stable releases. Want to test new bu
 
 _Channel(s): `Stable`_
 
-The easiest way for most users with iOS devices who want stable releases would be to download releases of LunaSea directly from the [App Store](https://www.lunasea.app/appstore)!
+The easiest way for most users with iOS devices who want stable releases would be to download releases of LunaSea directly from the [App Store](https://www.crushcodeworks.com/freesea/appstore)!
 
 ## TestFlight
 
@@ -23,19 +23,19 @@ The easiest way for most users with iOS devices to use test channels is using th
 {% tabs %}
 {% tab title="Stable" %}
 1. [Download TestFlight for iOS](https://apps.apple.com/app/testflight/id899247664)
-2. Join the [TestFlight stable channel](https://www.lunasea.app/testflight/stable)
+2. Join the [TestFlight stable channel](https://www.crushcodeworks.com/freesea/testflight/stable)
 3. Download LunaSea via the TestFlight application
 {% endtab %}
 
 {% tab title="Beta" %}
 1. [Download TestFlight for iOS](https://apps.apple.com/app/testflight/id899247664)
-2. Join the [TestFlight beta channel](https://www.lunasea.app/testflight/beta)
+2. Join the [TestFlight beta channel](https://www.crushcodeworks.com/freesea/testflight/beta)
 3. Download LunaSea via the TestFlight application
 {% endtab %}
 
 {% tab title="Edge" %}
 1. [Download TestFlight for iOS](https://apps.apple.com/app/testflight/id899247664)
-2. Join the [TestFlight edge channel](https://www.lunasea.app/testflight/edge)
+2. Join the [TestFlight edge channel](https://www.crushcodeworks.com/freesea/testflight/edge)
 3. Download LunaSea via the TestFlight application
 {% endtab %}
 {% endtabs %}
@@ -45,7 +45,7 @@ The easiest way for most users with iOS devices to use test channels is using th
 _Channel(s): `Stable`, `Beta`, `Edge`_\
 _Format(s): `.ipa`_
 
-All iOS releases are available in the [Build Bucket](https://builds.lunasea.app/#latest/)!
+All iOS releases are available in the [Build Bucket](https://builds.crushcodeworks.com/freesea/#latest/)!
 
 ## GitHub Releases
 

--- a/lunasea-docs/releases/linux.md
+++ b/lunasea-docs/releases/linux.md
@@ -10,7 +10,7 @@ If you want a stable experience, stick with stable releases. Want to test new bu
 
 _Channel(s): `Stable`, `Beta`, `Edge`_
 
-The easiest way for most users on graphic Linux distributions would be to download releases of LunaSea directly from [Snapcraft](https://www.lunasea.app/snapcraft)!
+The easiest way for most users on graphic Linux distributions would be to download releases of LunaSea directly from [Snapcraft](https://www.crushcodeworks.com/freesea/snapcraft)!
 
 {% tabs %}
 {% tab title="Stable" %}
@@ -37,7 +37,7 @@ sudo snap install lunasea --edge
 _Channel(s): `Stable`, `Beta`, `Edge`_\
 _Format(s): `.snap`, `.deb`, `.tar.gz`_
 
-All Linux releases are available in the [Build Bucket](https://builds.lunasea.app/#latest/)!
+All Linux releases are available in the [Build Bucket](https://builds.crushcodeworks.com/freesea/#latest/)!
 
 ## GitHub Releases
 

--- a/lunasea-docs/releases/macos.md
+++ b/lunasea-docs/releases/macos.md
@@ -3,7 +3,7 @@
 LunaSea is available on macOS 10.15+.
 
 {% hint style="info" %}
-If you want a stable experience, stick with stable releases. Want to test new builds of LunaSea? Read about the [build channels](https://docs.lunasea.app/getting-started/build-channels) to make the right choice!
+If you want a stable experience, stick with stable releases. Want to test new builds of LunaSea? Read about the [build channels](https://docs.crushcodeworks.com/freesea/getting-started/build-channels) to make the right choice!
 {% endhint %}
 
 ## TestFlight
@@ -15,19 +15,19 @@ The easiest way for most users with macOS devices would be to download releases 
 {% tabs %}
 {% tab title="Stable" %}
 1. [Download TestFlight for macOS](https://apps.apple.com/app/testflight/id899247664)
-2. Join the [TestFlight stable channel](https://www.lunasea.app/testflight/stable)
+2. Join the [TestFlight stable channel](https://www.crushcodeworks.com/freesea/testflight/stable)
 3. Download LunaSea via the TestFlight application
 {% endtab %}
 
 {% tab title="Beta" %}
 1. [Download TestFlight for macOS](https://apps.apple.com/app/testflight/id899247664)
-2. Join the [TestFlight beta channel](https://www.lunasea.app/testflight/beta)
+2. Join the [TestFlight beta channel](https://www.crushcodeworks.com/freesea/testflight/beta)
 3. Download LunaSea via the TestFlight application
 {% endtab %}
 
 {% tab title="Edge" %}
 1. [Download TestFlight for macOS](https://apps.apple.com/app/testflight/id899247664)
-2. Join the [TestFlight edge channel](https://www.lunasea.app/testflight/edge)
+2. Join the [TestFlight edge channel](https://www.crushcodeworks.com/freesea/testflight/edge)
 3. Download LunaSea via the TestFlight application
 {% endtab %}
 {% endtabs %}
@@ -37,7 +37,7 @@ The easiest way for most users with macOS devices would be to download releases 
 _Channel(s): `Stable`, `Beta`, `Edge`_\
 _Format(s): `.dmg`, `.zip`_
 
-All macOS releases are available in the [Build Bucket](https://builds.lunasea.app/#latest/)!
+All macOS releases are available in the [Build Bucket](https://builds.crushcodeworks.com/freesea/#latest/)!
 
 ## Homebrew Cask
 

--- a/lunasea-docs/releases/web.md
+++ b/lunasea-docs/releases/web.md
@@ -3,26 +3,26 @@
 LunaSea can be hosted as a web application for usage within any modern browser!
 
 {% hint style="info" %}
-If you want a stable experience, stick with stable releases. Want to test new builds of LunaSea? Read about the [build channels](https://docs.lunasea.app/getting-started/build-channels) to make the right choice!
+If you want a stable experience, stick with stable releases. Want to test new builds of LunaSea? Read about the [build channels](https://docs.crushcodeworks.com/freesea/getting-started/build-channels) to make the right choice!
 {% endhint %}
 
 ## Hosted Builds
 
 _Channel(s): `Stable`, `Beta`, `Edge`_
 
-All web releases of LunaSea are available on hosted instances by the LunaSea team! All communication and data stored is client-side, but there are some limitations of the platform which can be [viewed here](https://docs.lunasea.app/getting-started/platform-restrictions).
+All web releases of LunaSea are available on hosted instances by the LunaSea team! All communication and data stored is client-side, but there are some limitations of the platform which can be [viewed here](https://docs.crushcodeworks.com/freesea/getting-started/platform-restrictions).
 
 {% tabs %}
 {% tab title="Stable" %}
-Access the stable release [here](https://web.lunasea.app/)!
+Access the stable release [here](https://web.crushcodeworks.com/freesea/)!
 {% endtab %}
 
 {% tab title="Beta" %}
-Access the beta release [here](https://beta.web.lunasea.app/)!
+Access the beta release [here](https://beta.web.crushcodeworks.com/freesea/)!
 {% endtab %}
 
 {% tab title="Edge" %}
-Access the edge release [here](https://edge.web.lunasea.app/)!
+Access the edge release [here](https://edge.web.crushcodeworks.com/freesea/)!
 {% endtab %}
 {% endtabs %}
 
@@ -57,7 +57,7 @@ docker run -p 80:80 ghcr.io/jagandeepbrar/lunasea:edge
 _Channel(s): `Stable`, `Beta`, `Edge`_\
 _Format(s): `.zip`_
 
-All web releases are available in the [Build Bucket](https://builds.lunasea.app/#latest/)!
+All web releases are available in the [Build Bucket](https://builds.crushcodeworks.com/freesea/#latest/)!
 
 ## GitHub Releases
 

--- a/lunasea-docs/releases/windows.md
+++ b/lunasea-docs/releases/windows.md
@@ -3,7 +3,7 @@
 LunaSea is available on Windows 10+.
 
 {% hint style="info" %}
-If you want a stable experience, stick with stable releases. Want to test new builds of LunaSea? Read about the [build channels](https://docs.lunasea.app/getting-started/build-channels) to make the right choice!
+If you want a stable experience, stick with stable releases. Want to test new builds of LunaSea? Read about the [build channels](https://docs.crushcodeworks.com/freesea/getting-started/build-channels) to make the right choice!
 {% endhint %}
 
 ## Build Bucket
@@ -11,7 +11,7 @@ If you want a stable experience, stick with stable releases. Want to test new bu
 _Channel(s): `Stable`, `Beta`, `Edge`_\
 _Format(s): `.msix`, `.zip`_
 
-All Windows releases are available in the [Build Bucket](https://builds.lunasea.app/#latest/)!
+All Windows releases are available in the [Build Bucket](https://builds.crushcodeworks.com/freesea/#latest/)!
 
 ## GitHub Releases
 

--- a/lunasea-notification-service/README.md
+++ b/lunasea-notification-service/README.md
@@ -1,14 +1,14 @@
 # LunaSea Notification Service
 
-A TypeScript backend service that handles receiving webhooks from applications supported in [LunaSea](https://www.lunasea.app/github) and sends notifications to the respective user or device.
+A TypeScript backend service that handles receiving webhooks from applications supported in [LunaSea](https://www.crushcodeworks.com/freesea/github) and sends notifications to the respective user or device.
 
-> Setting up an instance of your own notification service is **not** necessary to get webhook notifications in LunaSea, simply use the hosted notification service available at [https://notify.lunasea.app](https://notify.lunasea.app). Setting up your own instance _will not_ send notifications to the officially published LunaSea application.
+> Setting up an instance of your own notification service is **not** necessary to get webhook notifications in LunaSea, simply use the hosted notification service available at [https://notify.crushcodeworks.com/freesea](https://notify.crushcodeworks.com/freesea). Setting up your own instance _will not_ send notifications to the officially published LunaSea application.
 >
 > Setting up your own instance of the notification service is only necessary when building your own version of LunaSea, which utilizes a different Firebase project.
 
 ## Usage
 
-For documentation on setting up the webhooks, please look at LunaSea's documentation [available here](https://notify.lunasea.app).
+For documentation on setting up the webhooks, please look at LunaSea's documentation [available here](https://notify.crushcodeworks.com/freesea).
 
 ## Installation (Docker)
 

--- a/lunasea-notification-service/src/server/server.ts
+++ b/lunasea-notification-service/src/server/server.ts
@@ -6,7 +6,7 @@ const logger = Logger.child({ module: 'express' });
 const server = express();
 
 const docs = async (request: express.Request, response: express.Response): Promise<void> => {
-  response.redirect(301, 'https://docs.lunasea.app/lunasea/notifications');
+  response.redirect(301, 'https://docs.crushcodeworks.com/freesea/lunasea/notifications');
 };
 
 const health = async (request: express.Request, response: express.Response): Promise<void> => {

--- a/lunasea/.github/ISSUE_TEMPLATE/config.yml
+++ b/lunasea/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature Requests & Support via Discord
-    url: https://www.lunasea.app/discord
+    url: https://www.crushcodeworks.com/freesea/discord
     about: Request new features and get support from the community
   - name: Support via GitHub Discussions
     url: https://github.com/JagandeepBrar/lunasea/discussions
     about: Ask questions and discuss with other community members
   - name: Support via Reddit
-    url: https://www.lunasea.app/reddit
+    url: https://www.crushcodeworks.com/freesea/reddit
     about: Ask the developer and other redditors for support and setup related topics

--- a/lunasea/.github/scripts/notify_discord_embed.js
+++ b/lunasea/.github/scripts/notify_discord_embed.js
@@ -1,6 +1,6 @@
 const getRelease = () => {
   const title = process.env.BUILD_TITLE;
-  let url = "https://builds.lunasea.app";
+  let url = "https://builds.crushcodeworks.com/freesea";
   if (title) url += `/#${title}/`;
   return `[Download](${url})`;
 };
@@ -9,7 +9,7 @@ const getWeb = () => {
   const flavor = process.env.BUILD_FLAVOR;
   let url = "";
   if (flavor !== "stable") url += `${process.env.BUILD_FLAVOR}.`;
-  url += "web.lunasea.app";
+  url += "web.crushcodeworks.com/freesea";
   return `[View Deployment](https://${url})`;
 };
 

--- a/lunasea/README.md
+++ b/lunasea/README.md
@@ -18,5 +18,5 @@ LunaSea even comes with support for webhook-based push notifications, multiple i
 
 > Please note that LunaSea is purely a remote control application, it does not offer any functionality without software installed on a server/computer.
 
-- [Email](mailto:hello@lunasea.app)
-- [Website](https://www.lunasea.app)
+- [Email](mailto:hello@crushcodeworks.com/freesea)
+- [Website](https://www.crushcodeworks.com/freesea)

--- a/lunasea/android/app/build.gradle
+++ b/lunasea/android/app/build.gradle
@@ -29,7 +29,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    namespace = "app.lunasea.lunasea"
+    namespace = "com.suvam.freesea"
     compileSdkVersion 35
 
     compileOptions {
@@ -46,7 +46,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "app.lunasea.lunasea"
+        applicationId "com.suvam.freesea"
         minSdkVersion 24
         targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()

--- a/lunasea/android/app/src/main/AndroidManifest.xml
+++ b/lunasea/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="app.lunasea.lunasea">
+    package="com.suvam.freesea">
     <application
         android:name="${applicationName}"
         android:usesCleartextTraffic="true"
-        android:label="LunaSea"
+        android:label="FreeSea"
         android:icon="@mipmap/ic_launcher">
         <meta-data android:name="asset_statements" android:resource="@string/asset_statements" />
         <activity

--- a/lunasea/android/app/src/main/res/values/strings.xml
+++ b/lunasea/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="asset_statements" translatable="false">[{\"include\": \"https://www.lunasea.app/.well-known/assetlinks.json\"}]</string>
+    <string name="asset_statements" translatable="false">[{\"include\": \"https://www.crushcodeworks.com/freesea/.well-known/assetlinks.json\"}]</string>
 </resources>

--- a/lunasea/ios/Runner.xcodeproj/project.pbxproj
+++ b/lunasea/ios/Runner.xcodeproj/project.pbxproj
@@ -426,9 +426,9 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = app.lunasea.lunasea;
+				PRODUCT_BUNDLE_IDENTIFIER = com.suvam.freesea;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development app.lunasea.lunasea";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development com.suvam.freesea";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -567,9 +567,9 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = app.lunasea.lunasea;
+				PRODUCT_BUNDLE_IDENTIFIER = com.suvam.freesea;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development app.lunasea.lunasea";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development com.suvam.freesea";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -605,10 +605,10 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = app.lunasea.lunasea;
+				PRODUCT_BUNDLE_IDENTIFIER = com.suvam.freesea;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore app.lunasea.lunasea";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore app.lunasea.lunasea";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.suvam.freesea";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.suvam.freesea";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/lunasea/ios/Runner/Info.plist
+++ b/lunasea/ios/Runner/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>LunaSea</string>
+	<string>FreeSea</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
This commit includes the initial steps for rebranding LunaSea to FreeSea and updating associated URLs.

Changes made so far:
- Updated Android package ID in `build.gradle` and `AndroidManifest.xml` from `app.lunasea.lunasea` to `com.suvam.freesea`.
- Updated Android app label in `AndroidManifest.xml` from "LunaSea" to "FreeSea".
- Updated iOS CFBundleName in `Info.plist` from "LunaSea" to "FreeSea".
- Updated iOS PRODUCT_BUNDLE_IDENTIFIER in `project.pbxproj` from `app.lunasea.lunasea` to `com.suvam.freesea`.
- Updated iOS PROVISIONING_PROFILE_SPECIFIER in `project.pbxproj` to reflect the new bundle ID.
- Began replacing hardcoded `lunasea.app` URLs with `crushcodeworks.com/freesea` and its subdomains in various documentation, script, and configuration files.

Files modified for URL replacement include:
- `lunasea-cloud-functions/functions/src/services/storage/index.ts`
- `lunasea-docs/README.md`
- `lunasea-docs/getting-started/build-channels.md`
- `lunasea-docs/getting-started/frequently-asked-questions.md` (multiple instances)
- `lunasea-docs/lunasea/notifications/custom-notifications.md` (multiple instances)
- `lunasea-docs/releases/android.md` (multiple instances)
- `lunasea-docs/releases/ios.md` (multiple instances)
- `lunasea-docs/releases/linux.md` (multiple instances)
- `lunasea-docs/releases/macos.md` (multiple instances)
- `lunasea-docs/releases/web.md` (multiple instances)
- `lunasea-docs/releases/windows.md` (multiple instances)
- `lunasea-notification-service/README.md` (multiple instances)
- `lunasea-notification-service/src/server/server.ts`
- `lunasea/.github/ISSUE_TEMPLATE/config.yml` (multiple instances)
- `lunasea/.github/scripts/notify_discord_embed.js` (multiple instances)
- `lunasea/README.md`
- `lunasea/android/app/src/main/res/values/strings.xml`